### PR TITLE
Replace getLocalMsgStream() with getOfflineFileStream() (removed from Thunderbird)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ADDON=changequote-$(VERSION)-tb.xpi
 xpi: $(ADDON)
 
 %.xpi:
-	zip -r $@ chrome.manifest chrome content defaults icon LICENSE manifest.json
+	zip -r $@ api background.js chrome.manifest chrome content defaults icon LICENSE manifest.json
 
 clean:
 	rm -f -- $(ADDON)

--- a/chrome/content/changequote/changequote.js
+++ b/chrome/content/changequote/changequote.js
@@ -332,9 +332,6 @@ var changequote = {
                 input.close();
             } else {
                 // This is for message stored in TB
-                // Objects that are required by getOfflineFileStream
-                var obj1 = new Object;
-                var obj2 = new Object;
                 var CQmessenger = Components.classes["@mozilla.org/messenger;1"].createInstance();
                 CQmessenger = CQmessenger.QueryInterface(Components.interfaces.nsIMessenger);
                 // Get the header in the form of nsIMsgDBHdr
@@ -343,7 +340,7 @@ var changequote = {
                 var ourfolder = hdr.folder;
                 // Open the stream, to read the folder starting from this message
                 try {
-                    ourfolder = ourfolder.getOfflineFileStream(hdr.messageKey, obj1, obj2);
+                    ourfolder = ourfolder.getLocalMsgStream(hdr);
                 } catch (e) {
                     // error in reading the streaming, this happens with IMAP message, without offline use
                     CQmailformat = 0;

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "applications": {
         "gecko": {
             "id": "changequote@caligraf",
-            "strict_min_version": "91.0",
+            "strict_min_version": "102.0",
             "strict_max_version": "102.*"
         }
     },


### PR DESCRIPTION
Function `getOfflineFileStream()` was [removed in Thunderbird 102][0], in favour of `getLocalMsgStream()` which is supposed to "unify local/offline message reading".

This fixes a bug on recent Thunderbird where custom format dates would not be applied, because the call to the now undefined `getOfflineFileStream()` function would fail, `CQdate` would be set to `"-1"`, and `decodeCustomizedDateSender()` would never be called.

Given that `getLocalMsgStream()` is new, update the minimum version requirement for the add-on.

[0]: https://hg.mozilla.org/comm-central/rev/21bbb5c18ad05b92b70454648b0e5630a95e0190

Second commit is unrelated and updates the `Makefile` following the recent addition of source files to the repo.