### PR TITLE
Fix 'Reply List' functionality

### DIFF
--- a/chrome/content/changequote/messenger.js
+++ b/chrome/content/changequote/messenger.js
@@ -35,12 +35,12 @@ function onLoad(activatedWhileWindowOpen) {
     if (typeof MsgReplyToListMessageORIG == "undefined" && typeof window.MsgReplyToListMessage != "undefined") {
         var MsgReplyToListMessageORIG = window.MsgReplyToListMessage;
         window.MsgReplyToListMessage = function (event) {
-            var messageArray = [CQGetFirstSelectedMessage()];
+            var messageArray = [window.changequote.CQGetFirstSelectedMessage()];
             var CQheaders_news = CQprefs.getBoolPref("changequote.set.headers.news");
             if (CQheaders_news)
-                loadHeader(messageArray[0], true, true, false);
+                window.changequote.loadHeader(messageArray[0], true, true, false);
             else
-                standardHeader(messageArray[0]);
+                window.standardHeader(messageArray[0]);
             MsgReplyToListMessageORIG.apply(this, arguments);
         };
     }
@@ -107,11 +107,11 @@ function onLoad(activatedWhileWindowOpen) {
                     if (CQdateformat == 2)
                         CQparseheader(uri);
                     if (CQheaders_type == 0)
-                        loadHeader(uri, false, false, true);
+                        window.changequote.loadHeader(uri, false, false, true);
                     else if (CQheaders_type == 1)
-                        standardHeader(null);
+                        window.standardHeader(null);
                     else
-                        loadHeader(uri, true, false, true);
+                        window.changequote.loadHeader(uri, true, false, true);
                     window.gMsgCompose.quoteMessage(uri);
                 }
             }


### PR DESCRIPTION
Currently the 'Reply List' button does not do anything when clicked and the following error message can be seen in the Error Console:

```
  Uncaught ReferenceError: CQGetFirstSelectedMessage is not defined
      MsgReplyToListMessage chrome://changequote/content/changequote/messenger.js:38
      oncommand chrome://messenger/content/messenger.xhtml:1
  messenger.js:38:33
```

This adds dotted paths to various function calls that appeared in the Error Console.

(Note that in order to use a customized header with 'Reply List', you must enable "Use customized headers for newsgroups" on the "Newsgroup reply headers" tab of the add-on config.)

Closes #21