### PR TITLE
Update for Thunderbird 128

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,21 @@ ADDON=changequote-$(VERSION)-tb.xpi
 
 xpi: $(ADDON)
 
-%.xpi:
-	zip -r $@ chrome.manifest chrome content defaults icon LICENSE manifest.json
+SRC :=
+SRC += $(shell find _locales -type f)
+SRC += $(shell find api -type f)
+SRC += $(shell find chrome -type f)
+SRC += $(shell find icon -type f)
+SRC += $(shell find options -type f)
+SRC += background.js
+SRC += compose.js
+SRC += LICENSE
+SRC += manifest.json
+
+%.xpi: $(SRC)
+	zip -r $@ $^
 
 clean:
 	rm -f -- $(ADDON)
 
-.PHONY: clean
+.PHONY: clean xpi

--- a/api/LegacyPrefs/implementation.js
+++ b/api/LegacyPrefs/implementation.js
@@ -36,16 +36,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { ExtensionCommon } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionCommon.jsm"
+const { ExtensionCommon } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionCommon.sys.mjs"
 );
-var { ExtensionUtils } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionUtils.jsm"
+const { ExtensionUtils } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionUtils.sys.mjs"
 );
-var { ExtensionError } = ExtensionUtils;
+const { ExtensionError } = ExtensionUtils;
 
-var Services = globalThis.Services || 
-  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+const Services = globalThis.Services;
 
 
 var LegacyPrefs = class extends ExtensionCommon.ExtensionAPI {

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,14 @@
     "browser_specific_settings": {
         "gecko": {
             "id": "changequote@caligraf",
-            "strict_min_version": "115.0",
-            "strict_max_version": "115.*"
+            "strict_min_version": "128.0",
+            "strict_max_version": "129.*"
         }
     },
     "name": "changeQuote",
     "description": "Change the reply header and the reply format",
     "author": "Caligraf",
-    "version": "1.7.11",
+    "version": "1.8.0",
     "default_locale": "en",
     "homepage_url": "https://github.com/caligraf/ChangeQuote/wiki",
     "icons": {


### PR DESCRIPTION
I managed to get the add-on running on Thunderbird 129 (current beta) with minimal changes. Please double-check, and consider merging the update if it works for you as well.

Fixes: #49 