### PR TITLE
Fix custom sender's date formatting

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -84,14 +84,11 @@ async function updateMessage(composeDetails, messageHeader, messagePart) {
                     });
                 }
                 let receivedDate = "";
-                let received = messagePart.headers["received"];
+                let received = messagePart.headers["date"];
                 if (received) {
                     let size = received.length;
                     if (size >= 1) {
-                        let receivedDateTab = received[size - 1].split(";");
-                        if (receivedDateTab.length > 1) {
-                            receivedDate = receivedDateTab[1];
-                        }
+                        receivedDate = received[0];
                     }
                 }
 


### PR DESCRIPTION
Fix a regression from commit b6bb418b376c.

Before that commit, we would retrieve the sender's date from the `Date:` header ([link][0]). Then we had a function, specific to sender's date, called `decodeCustomizedDateSender()` and that would extract the right date, time zone, and apply the custom formatting ([link][1]).

But after this commit, the add-on picks the sender's date from the `Received:` header field instead ([link][2]). This does not look correct: for mailing lists for example this field seems to use the time zone from the mailing list server rather than the one from the sender. So we lose the information about the sender here already. And there seems to be a second issue: when the add-on processes the date after that, it creates a new `Date()` object from the collected string ([link][3]). As far as I understand, this `Date` object stores no information about the time zone from the original string, it is just a time stamp that renders with `toString()` into the user's time zone. So we don't have any info left when trying to recover the time zone in `decodeCustomizedDate()` ([link][4]).

To fix this:

  - Revert getting sender's date from `Received:` header field to `Date:` field, to pick the right date.
  - Extract sender's time zone from `receivedDateString` and pass it to `decodeCustomizedDate()`, so we don't lose the time zone information by relying only on `receiveDate`.
  - Process all relevant date fields with `DateTimeFormat()` formatters, to take the time zone into account.

[0]: https://github.com/caligraf/ChangeQuote/commit/b6bb418b376c7ca6e2f67fa792e11067d9cf0230#diff-1af7b99192b3daf6e19b1a644859de38c8c4cfa9e3f367addf0861821a99bc2fL385
[1]: https://github.com/caligraf/ChangeQuote/commit/b6bb418b376c7ca6e2f67fa792e11067d9cf0230#diff-1af7b99192b3daf6e19b1a644859de38c8c4cfa9e3f367addf0861821a99bc2fL601
[2]: https://github.com/caligraf/ChangeQuote/commit/b6bb418b376c7ca6e2f67fa792e11067d9cf0230#diff-52674c8369169705f299c119059dd427b5347f6164a7b141b23428deadff9bf1R68-R78
[3]: https://github.com/caligraf/ChangeQuote/commit/b6bb418b376c7ca6e2f67fa792e11067d9cf0230#diff-bb06783fccd762e4d905ab922491e954a9fbaf708a1acbf53dff92872b0bcd3bR91-R92
[4]: https://github.com/caligraf/ChangeQuote/commit/b6bb418b376c7ca6e2f67fa792e11067d9cf0230#diff-bb06783fccd762e4d905ab922491e954a9fbaf708a1acbf53dff92872b0bcd3bR42-R44

Fixes: #48